### PR TITLE
Fix a flaky test by cleaning a polluted state

### DIFF
--- a/test/test_occam_data.py
+++ b/test/test_occam_data.py
@@ -99,6 +99,7 @@ def test_occam_data_constructor_files():
 def test_occam_data_attributes():
     occam_data, fort1, fort7, xyz = _create_default_occam_data_object()
     _assert_all_attributes_present_and_equal(occam_data, fort1, fort7, xyz)
+    shutil.rmtree(class_dir)
 
 
 def test_occam_data_wrong_input():


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `test/test_occam_data.py::test_occam_data_not_save_to_npy`, which can fail after running `test/test_occam_data.py::test_occam_data_attributes`, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest test/test_occam_data.py::test_occam_data_attributes test/test_occam_data.py::test_occam_data_not_save_to_npy
```
# Expected result
`test/test_occam_data.py::test_occam_data_not_save_to_npy` should pass after running `test/test_occam_data.py::test_occam_data_attributes`.

# Actual result
```
    def test_occam_data_not_save_to_npy():
>       assert not os.path.exists(class_dir)
E       AssertionError: assert not True
E        +  where True = <function exists at 0x7f3b6d24cca0>('/home/yyy/pythonOD/explore_test/cprojects/OccamTools/test/../data/class_data')
E        +    where <function exists at 0x7f3b6d24cca0> = <module 'posixpath' from '/usr/lib/python3.8/posixpath.py'>.exists
E        +      where <module 'posixpath' from '/usr/lib/python3.8/posixpath.py'> = os.path

test/test_occam_data.py:217: AssertionError
```
# Why it fails
The test class directory is not deleted after running `test/test_occam_data.py::test_occam_data_attributes`, which leads to a pollution.
# Fix
Delete `class_dir` at the end of `test/test_occam_data.py::test_occam_data_attributes`
